### PR TITLE
Update current monitor sampling frequency

### DIFF
--- a/LoadRegulator.h
+++ b/LoadRegulator.h
@@ -39,6 +39,8 @@ float target_voltage; // desired voltage across load, in volts
 float measured_current; // current going through load, in amps
 float control_current; // controlled variable adjusted to get target current, in amps
 float measured_voltage; // in volts
+// misc
+unsigned long last_cur_time; // last time current was measured; in ms
 operation_mode op_mode;
 
 public:

--- a/settings.h
+++ b/settings.h
@@ -23,6 +23,8 @@
 #define SET_LR_CV_CUR_STEP (0.001) // in mA
 // CV initial voltage
 #define SET_LR_CV_INIT_V (100) // in V
+// Current sampling period
+#define SET_LR_CUR_SAMPLE_PERIOD (17) // in ms
 
 /********************* Debugger *********************/
 // Define DEBUG as 1 to enable debugger
@@ -47,6 +49,6 @@
 // Encoder
 #define SET_UI_ENC_LONG_PRESS_THRESH (1000) // time necessary to be considered long press, in ms
 // LCD
-#define SET_UI_LCD_UPDATE_PERIOD (100) // time between full screen updates, in ms
+#define SET_UI_LCD_UPDATE_PERIOD (200) // time between full screen updates, in ms
 // Screen
 #define SET_UI_SCREEN_MAX_LINES (8)


### PR DESCRIPTION
Previously current monitor would be querried at 1 kHz. Now it's querried around 60 Hz. This reduces unnecessary traffic on the I2C bus.