### PR TITLE
Change LoadRegulator architecture

### DIFF
--- a/Debugger.cpp
+++ b/Debugger.cpp
@@ -26,7 +26,7 @@ void Debugger::run_debugger(){
 		// Update values to report
 		float LR_measured_voltage = LR_r.get_measured_voltage();
 		float LR_measured_current = LR_r.get_measured_current();
-		float LR_control_current = LR_r.get_control_current();
+		float LR_control_current = 0;
 	
 		// Construct string
 		LED_G.on();
@@ -44,7 +44,7 @@ void Debugger::run_debugger(){
 				append_float(LR_r.get_target_current());
 				strcat(char_tx_buffer, " A (");
 				// Control current
-				append_float(LR_r.get_control_current());
+				append_float(LR_control_current);
 				strcat(char_tx_buffer, " A)");
 				break;
 			case(LoadRegulator::CP):
@@ -60,7 +60,7 @@ void Debugger::run_debugger(){
 				append_float(LR_r.get_target_power());
 				strcat(char_tx_buffer, " W (");
 				// Control current
-				append_float(LR_r.get_control_current());
+				append_float(LR_control_current);
 				strcat(char_tx_buffer, " A)");
 				break;
 			case(LoadRegulator::CR):
@@ -76,7 +76,7 @@ void Debugger::run_debugger(){
 				append_float(LR_r.get_target_resistance());
 				strcat(char_tx_buffer, " R (");
 				// Control current
-				append_float(LR_r.get_control_current());
+				append_float(LR_control_current);
 				strcat(char_tx_buffer, " A)");
 				break;
 			case(LoadRegulator::CV):
@@ -92,7 +92,7 @@ void Debugger::run_debugger(){
 				append_float(LR_measured_current);
 				strcat(char_tx_buffer, " A, ");
 				// Control current
-				append_float(LR_r.get_control_current());
+				append_float(LR_control_current);
 				strcat(char_tx_buffer, " A)");
 				break;
 			case(LoadRegulator::OFF):

--- a/LoadRegulator.h
+++ b/LoadRegulator.h
@@ -32,7 +32,6 @@ struct LR_state
 	// Read only
 	float _measured_current;
 	float _measured_voltage;
-	float _control_current;
 };
 
 private:
@@ -48,15 +47,18 @@ MAX5216 current_control;
 ADS8685 volt_monitor;
 // Data
 float cal_zero; // voltage at zero current
-float target_current; // desired current going through load, in amps
-float target_power; // desired power dissipated by load, in watts
-float target_resistance; // desired resistance of load, in ohms
-float target_voltage; // desired voltage across load, in volts
-float measured_current; // current going through load, in amps
-float control_current; // controlled variable adjusted to get target current, in amps
+float target_current; // target current in CC mode, in amps
+float target_power; // target power in CP mode, in watts
+float target_resistance; // target resistance in CR mode, in ohms
+float target_voltage; // target voltage in CV mode, in volts
+float measured_current; // measured current going through load, in amps
+float desired_current; // desired current through load
+float offset; // offset for accurate current
 float measured_voltage; // in volts
 // misc
 unsigned long last_cur_time; // last time current was measured; in ms
+unsigned long last_desired_time; // last time desired was updated
+unsigned long last_offset_time; // last time offset was updated
 operation_mode op_mode;
 
 public:
@@ -77,7 +79,6 @@ void set_target_current(float val){
 	// val is in amps
 	// control current starts same as target current, adjusted in regulate method
 	target_current = val;
-	control_current = val;
 }
 float get_target_current(){
 	// returns target current in amps
@@ -87,11 +88,6 @@ float get_measured_current(){
 	// returns measured current in amps
 	return measured_current;
 }
-float get_control_current(){
-	// returns control current, in amps
-	return control_current;
-}
-void adjust_control_current();
 // Power
 void set_target_power(float val){
 	// val is in watts
@@ -134,7 +130,6 @@ void get_state(LR_state &state){
 	state._update = false;
 	state._measured_current = measured_current;
 	state._measured_voltage = measured_voltage;
-	state._control_current = control_current;
 }
 void set_state(LR_state &state){
 	// Only uses writable members

--- a/settings.h
+++ b/settings.h
@@ -15,10 +15,16 @@
 
 /********************* LOAD REGULATOR *********************/
 // Load Regulator sampling frequency
-// Set to 1 ms
+// Set to 100 us (10 kHz)
 #define SET_LR_TIMER_NUMBER (HAL_Timer::TIMER_TIMER1)
 #define SET_LR_TIMER_DIV (HAL_Timer::TIMER_CLK_DIV64)
-#define SET_LR_TIMER_TOP (249)
+#define SET_LR_TIMER_TOP (24)
+// periods
+#define SET_LR_DESIRED_UPDATE_PERIOD (10) // time between target updates, in units of LR timer
+#define SET_LR_OFFSET_UPDATE_PERIOD (167) // time between offset updates, in units of LR timer
+// offset limits
+#define SET_LR_OFFSET_MIN (-0.05) // offset minimum, in amps
+#define SET_LR_OFFSET_MAX (0.05) // offset maxcimum, in amps
 // Current control parameters
 #define SET_LR_CUR_ERROR_SCALER (0.5)
 // Zero current calibration amount


### PR DESCRIPTION
Previously, DAC output was controlled almost entirely by current sensor. This was necessary as DAC output did not map well to current through the load. This was found to be a hardware issue (opamp was unstable; fixed by increased feedback capacitor). Since problem has been solved, architecture has changed to allow DAC output to update faster, producing better responses to varying input voltage.